### PR TITLE
Terminal doesn't go back to normal state if gex exits with os.Exit(1)

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ func main() {
 	if err != nil {
 		fmt.Println("Application not running on " + fmt.Sprintf("%s:%d", *givenHost, *givenPort))
 		fmt.Println(err)
+		t.Close()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Right now when running `gex` with default args, flags and it can't connect to the host it exits the program with code 1 and forgets to close termbox session so mouse cursor location gets registered whenever i click on the terminal.

This PR aims to fix the issue by adding a `t.Close()` before calling `os.Exit(1)` since it doesn't trigger defer functions.