### PR TITLE
Fix termbox not cleaning up if we use --help flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,6 @@ func main() {
 	if err != nil {
 		fmt.Println("Application not running on " + fmt.Sprintf("%s:%d", *givenHost, *givenPort))
 		fmt.Println(err)
-		t.Close()
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -82,19 +82,14 @@ type playType int
 func main() {
 	view()
 
+	flag.Parse()
+
 	// Init internal variables
 	info := Info{}
 	info.blocks = new(Blocks)
 	info.transactions = new(Transactions)
 
 	connectionSignal := make(chan string)
-	t, err := termbox.New()
-	if err != nil {
-		panic(err)
-	}
-	defer t.Close()
-
-	flag.Parse()
 
 	networkInfo, err := getFromRPC("status")
 	if err != nil {
@@ -265,6 +260,12 @@ func main() {
 	go writeBlocks(ctx, info, blocksWidget, connectionSignal)
 	go writeTransactions(ctx, info, transactionWidget, connectionSignal)
 	go writeBlockDonut(ctx, green, 0, 20, 700*time.Millisecond, playTypePercent, connectionSignal)
+
+	t, err := termbox.New()
+	if err != nil {
+		panic(err)
+	}
+	defer t.Close()
 
 	// Draw Dashboard
 	c, err := container.New(


### PR DESCRIPTION
It seems that golang does the `os.Exit(0)` in `flag.Parse` when user passes `--help` or `-h` flag so it causes the same issue as #25